### PR TITLE
clear out any junk excel files

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -16,6 +16,7 @@ app = FastAPI()
 @app.post(f"{URL_PATH}/uploadfiles/")
 async def create_upload_files(files: list[UploadFile], background_tasks: BackgroundTasks):
     # copies the files from the user directory into this repo, runs function from tmc_summarizer, returns summary file, cleans out excel files
+    delete_excel()
     for file in files:
         with open(file.filename, "wb") as buffer:
             shutil.copyfileobj(file.file, buffer)


### PR DESCRIPTION
run delete_excel() at the onset in the event that the wrong filename/type is uploaded, clears it out so the rest of the script can still run. 